### PR TITLE
[fix] fix typo in template

### DIFF
--- a/src/components/VueFlux.vue
+++ b/src/components/VueFlux.vue
@@ -18,7 +18,7 @@
 
 		<slot name="spinner">
 			<div v-if="!loaded" class="spinner">
-				<div class="pct">{{ this.loadPct }}%</div>
+				<div class="pct">{{ loadPct }}%</div>
 				<div class="border"></div>
 			</div>
 		</slot>


### PR DESCRIPTION
I found a typo in the template of vue-flux.
This caused "NaN%" when every time images were loading.