### PR TITLE
Rename getAdaptedSizeByWith to getAdaptedSizeByWidth in ResizeCalculator

### DIFF
--- a/ia.txt
+++ b/ia.txt
@@ -7032,7 +7032,7 @@ export default class ResizeCalculator {
 			this.realOrientation === Orientations.portrait &&
 			resizeType === ResizeTypes.fill
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		if (
@@ -7041,7 +7041,7 @@ export default class ResizeCalculator {
 			resizeAspectRatio >= this.realAspectRatio &&
 			resizeType === ResizeTypes.fill
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		if (
@@ -7050,7 +7050,7 @@ export default class ResizeCalculator {
 			resizeAspectRatio < this.realAspectRatio &&
 			resizeType === ResizeTypes.fit
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		if (
@@ -7058,7 +7058,7 @@ export default class ResizeCalculator {
 			this.realOrientation === Orientations.landscape &&
 			resizeType === ResizeTypes.fit
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		if (
@@ -7067,7 +7067,7 @@ export default class ResizeCalculator {
 			resizeAspectRatio > this.realAspectRatio &&
 			resizeType === ResizeTypes.fill
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		if (
@@ -7076,13 +7076,13 @@ export default class ResizeCalculator {
 			resizeAspectRatio <= this.realAspectRatio &&
 			resizeType === ResizeTypes.fit
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		return this.getAdaptedSizeByHeight(resizeSize);
 	}
 
-	private getAdaptedSizeByWith(resizeSize: Size) {
+	private getAdaptedSizeByWidth(resizeSize: Size) {
 		return new Size({
 			width: resizeSize.width.value,
 			height: resizeSize.width.value! / this.realAspectRatio,

--- a/src/shared/ResizeCalculator/ResizeCalculator.ts
+++ b/src/shared/ResizeCalculator/ResizeCalculator.ts
@@ -65,7 +65,7 @@ export default class ResizeCalculator {
 			this.realOrientation === Orientations.portrait &&
 			resizeType === ResizeTypes.fill
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		if (
@@ -74,7 +74,7 @@ export default class ResizeCalculator {
 			resizeAspectRatio >= this.realAspectRatio &&
 			resizeType === ResizeTypes.fill
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		if (
@@ -83,7 +83,7 @@ export default class ResizeCalculator {
 			resizeAspectRatio < this.realAspectRatio &&
 			resizeType === ResizeTypes.fit
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		if (
@@ -91,7 +91,7 @@ export default class ResizeCalculator {
 			this.realOrientation === Orientations.landscape &&
 			resizeType === ResizeTypes.fit
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		if (
@@ -100,7 +100,7 @@ export default class ResizeCalculator {
 			resizeAspectRatio > this.realAspectRatio &&
 			resizeType === ResizeTypes.fill
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		if (
@@ -109,13 +109,13 @@ export default class ResizeCalculator {
 			resizeAspectRatio <= this.realAspectRatio &&
 			resizeType === ResizeTypes.fit
 		) {
-			return this.getAdaptedSizeByWith(resizeSize);
+			return this.getAdaptedSizeByWidth(resizeSize);
 		}
 
 		return this.getAdaptedSizeByHeight(resizeSize);
 	}
 
-	private getAdaptedSizeByWith(resizeSize: Size) {
+	private getAdaptedSizeByWidth(resizeSize: Size) {
 		return new Size({
 			width: resizeSize.width.value,
 			height: resizeSize.width.value! / this.realAspectRatio,


### PR DESCRIPTION
### Motivation

- Fix a typo in the private helper name to improve readability (`With` -> `Width`).
- Ensure method name accurately reflects it adapts size by width.
- Keep source and generated IA bundle consistent.
- Prevent future confusion or breakage from mismatched symbol names.

### Description

- Renamed the private method `getAdaptedSizeByWith` to `getAdaptedSizeByWidth` in `src/shared/ResizeCalculator/ResizeCalculator.ts`.
- Updated all call sites inside `ResizeCalculator` to call `getAdaptedSizeByWidth`.
- Updated the generated IA bundle `ia.txt` to reflect the corrected method name.
- No other behavior changes — logic and signatures remain the same.

### Testing

- No automated tests were run for this change.
- Changes were verified by updating source and IA references and committing the modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694582f0e3b8832095c9ddc2630cb67e)