### PR TITLE
Fix README Img usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Add component. This one has all the complements, so you can remove the ones you 
    });
 
    const vfRscs = shallowReactive([
-      new Img('URL1' 'img 1'),
-      new Img('URL2' 'img 2'),
-      new Img('URL3' 'img 3'),
+      new Img('URL1', 'img 1'),
+      new Img('URL2', 'img 2'),
+      new Img('URL3', 'img 3'),
    ]);
 
    const vfTransitions = shallowReactive([Book, Zip]);
@@ -144,7 +144,7 @@ As simple as this.
 <script setup>
    import { FluxParallax, Img } from 'vue-flux';
 
-   const rsc = new Img('URL1' 'img 1');
+   const rsc = new Img('URL1', 'img 1');
 </script>
 
 <template>


### PR DESCRIPTION
### Motivation
- Fix syntax errors in README examples where the `Img` constructor arguments were missing a separator.
- Ensure examples in documentation match the `Img` constructor signature defined in the codebase (`src/resources/Img/Img.ts`).
- Prevent confusion for users copying the sample snippets into projects.

### Description
- Updated `README.md` to add the missing commas in `Img` constructor calls, e.g. changed `new Img('URL1' 'img 1')` to `new Img('URL1', 'img 1')`.
- Fixed occurrences in the example resources array and the Parallax snippet.
- Only `README.md` was modified (documentation-only change).

### Testing
- No automated tests were run; this is a documentation-only change.
- Snippets were validated by inspection against the `Img` constructor signature (`constructor(src: string, caption?: string, ...)`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458490eee48320ace394ea1d6c9f45)