### PR TITLE
Compute FluxParallax view.top relative to non-window scroll holders

### DIFF
--- a/src/components/FluxParallax/FluxParallax.vue
+++ b/src/components/FluxParallax/FluxParallax.vue
@@ -142,7 +142,16 @@
 
 		view.width = $el.value!.clientWidth;
 		view.height = $el.value!.clientHeight;
-		view.top = $el.value!.getBoundingClientRect().top + window.scrollY;
+
+		const elementRect = $el.value!.getBoundingClientRect();
+
+		if (holder === window) {
+			view.top = elementRect.top + window.scrollY;
+		} else {
+			const holderRect = holder.getBoundingClientRect();
+
+			view.top = elementRect.top - holderRect.top + holder.scrollTop;
+		}
 
 		rsc.displaySize.update(display);
 		const fillProps = rsc.resizeProps.value;


### PR DESCRIPTION
### Motivation
- Parallax positioning was computed only against `window` coordinates which produced incorrect offsets when the component is inside a scrolling container (`holder !== window`).
- Need to compute `view.top` in the same scroll coordinate space used by `onScroll()` so `handle.relative()` receives a consistent position.

### Description
- Update `resize()` in `src/components/FluxParallax/FluxParallax.vue` to compute `view.top` differently depending on the `holder`:
  - If `holder === window`, keep `view.top = elementRect.top + window.scrollY`.
  - If `holder !== window`, compute `view.top = elementRect.top - holderRect.top + holder.scrollTop` so it is relative to the holder's scroll coordinate.
- Added intermediate `elementRect` and `holderRect` calculations and preserved all existing display/background updates and the final `onScroll()` call.
- Ensures `handle.relative()` receives a `positionY` that is consistent with the `scrollTop` value used in `onScroll()` for non-window holders.

### Testing
- No automated tests were executed as part of this change.
- No unit tests were added/modified in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69458ca7e40c8320b6f54ea4a1f6eaf5)